### PR TITLE
Sb disable inactive govs

### DIFF
--- a/src/scripts/Governors.js
+++ b/src/scripts/Governors.js
@@ -27,9 +27,15 @@ export const Governors = () => {
     }
     
     const govHTML = governors.map(gov => {
-        return `
-        <option value="${gov.id}">${gov.name}</option>
-        `
+        if (gov.isActiveGov) {
+            return `
+            <option value="${gov.id}">${gov.name}</option>
+            `
+        } else {
+            return `
+            <option value =${gov.id} disabled>${gov.name}</option>
+            `
+        }
                        
     } )
 


### PR DESCRIPTION
# Description

When a governor is inactive, the option to select this governor is disabled in the dropdown menu

## Checklist:
Looks to be working to me,  but let me know if you find something funky.
